### PR TITLE
Cache ScalablyTyped artifacts on CI

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,6 +25,7 @@ jobs:
           path: |
             ~/.cache/coursier
             ~/.ivy2
+            ~/.cache/scalablytyped
             .target/scala-2.13/scalajs-bundler/main/node_modules
           key: ${{ runner.os }}-cache-${{ github.run_id }}
           restore-keys: |

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -22,6 +22,7 @@ jobs:
           path: |
             ~/.cache/coursier
             ~/.ivy2
+            ~/.cache/scalablytyped
             .target/scala-2.13/scalajs-bundler/main/node_modules
           key: ${{ runner.os }}-cache-${{ github.run_id }}
           restore-keys: |


### PR DESCRIPTION
https://scalablytyped.org/docs/conversion-options#customize-the-build

> By default we store caches and built artifacts in ~/.cache/scalablytyped or a similar directory for your operating system.